### PR TITLE
fix(message): getImMessage IndexOutOfBoundsException

### DIFF
--- a/android/src/main/java/com/kangfenmao/nim/model/Message.java
+++ b/android/src/main/java/com/kangfenmao/nim/model/Message.java
@@ -71,7 +71,7 @@ public class Message {
     uuids.add(this.id);
     List<IMMessage> imMessages = NIMClient.getService(MsgService.class).queryMessageListByUuidBlock(uuids);
 
-    return imMessages == null ? null : imMessages.get(0);
+    return (imMessages == null || imMessages.isEmpty()) ? null : imMessages.get(0);
   }
 
   public String getContentSummary() {


### PR DESCRIPTION
用户点击小组会话列表闪退, 查看sentry报错, 定位代码 **/model/Message.java 64行** 

imMessages 为空数组时取了第一位的元素导致错误
```Java
  return imMessages == null ? null : imMessages.get(0);
```

![image](https://user-images.githubusercontent.com/45527770/94637175-7a841e80-0309-11eb-8fe3-95b2760957a0.png)
